### PR TITLE
Use positional arguments (role, host)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,23 +8,20 @@ Example usage
 
 .. code-block:: bash
 
-    $ ansible-role-apply --host=vagrant --role=docker --sudo --show-playbook
-    -------------------------------------------------------------------------------
-    #!/usr/bin/env ansible-playbook
-    ---
-    - hosts:
-        - vagrant
-      roles:
-        - docker
-      sudo: True
-    -------------------------------------------------------------------------------
+    $ ansible-role-apply --help
+    Usage: ansible-role-apply [OPTIONS] ROLE HOSTS
 
+    Options:
+      -s, --sudo / --no-sudo
+      --show-playbook / --no-show-playbook
+      --help                          Show this message and exit.
+
+    $ ansible-role-apply docker vagrant --sudo
+    ...
     PLAY [vagrant] ****************************************************************
 
     GATHERING FACTS ***************************************************************
     ok: [vagrant]
-
     ...
-
     PLAY RECAP ********************************************************************
     vagrant                    : ok=16   changed=1    unreachable=0    failed=0

--- a/ansible_role_apply.py
+++ b/ansible_role_apply.py
@@ -5,12 +5,12 @@ import click
 
 
 @click.command()
-@click.option('--host', 'hosts', multiple=True)
-@click.option('--role', 'roles', multiple=True)
 @click.option('--sudo/--no-sudo', '-s')
 @click.option('--show-playbook/--no-show-playbook')
-def ansible_role_apply(hosts, roles, sudo, show_playbook):
-    playbook_content = get_playbook_content(hosts, roles, sudo)
+@click.argument('role')
+@click.argument('hosts')
+def ansible_role_apply(sudo, show_playbook, role, hosts):
+    playbook_content = get_playbook_content(role, hosts, sudo)
     if show_playbook:
         click.secho(79 * '-', fg='yellow')
         click.secho('#!/usr/bin/env ansible-playbook', fg='yellow')
@@ -35,9 +35,9 @@ def get_playbook_roles(roles):
     return playbook_roles
 
 
-def get_playbook_content(hosts, roles, sudo):
-    playbook_hosts = get_playbook_hosts(hosts)
-    playbook_roles = get_playbook_roles(roles)
+def get_playbook_content(role, hosts, sudo):
+    playbook_roles = get_playbook_roles([role])
+    playbook_hosts = get_playbook_hosts([hosts])
     playbook_content = """\
 ---
 - hosts:


### PR DESCRIPTION
instead of named options like `--role` and `--host`. E.g.:

```
$ ansible-role-apply --help
Usage: ansible-role-apply [OPTIONS] ROLE HOSTS

Options:
  -s, --sudo / --no-sudo
  --show-playbook / --no-show-playbook
  --help                          Show this message and exit.

$ ansible-role-apply docker vagrant --sudo
...
PLAY [vagrant] ****************************************************************

GATHERING FACTS ***************************************************************
ok: [vagrant]
...
PLAY RECAP ********************************************************************
vagrant                    : ok=16   changed=1    unreachable=0    failed=0
```

Fixes: GH-1

Cc: @sudarkoff
